### PR TITLE
Ignition Gazebo integration with lbr_fri_ros2_stack

### DIFF
--- a/lbr_bringup/launch/gazebo.launch.py
+++ b/lbr_bringup/launch/gazebo.launch.py
@@ -3,7 +3,11 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from lbr_bringup.description import LBRDescriptionMixin
 from lbr_bringup.gazebo import GazeboMixin
 from lbr_bringup.ros2_control import LBRROS2ControlMixin
+from launch.actions import ExecuteProcess
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import Node
 
+import os
 
 def generate_launch_description() -> LaunchDescription:
     ld = LaunchDescription()
@@ -53,4 +57,5 @@ def generate_launch_description() -> LaunchDescription:
             controller=LaunchConfiguration("ctrl")
         )
     )
+
     return ld

--- a/lbr_bringup/lbr_bringup/gazebo.py
+++ b/lbr_bringup/lbr_bringup/gazebo.py
@@ -20,6 +20,7 @@ class GazeboMixin:
                     ]
                 )
             ),
+            launch_arguments={'gz_args': ['-r ', 'empty.sdf'], 'on_exit_shutdown': 'true'}.items(),
             **kwargs,
         )
 
@@ -40,7 +41,7 @@ class GazeboMixin:
                 "-name",
                 robot_name,
                 "-topic",
-                "/robot_description",
+                "robot_description",
             ]
             + [item for pair in zip(label, tf) for item in pair],
             output="screen",

--- a/lbr_bringup/lbr_bringup/gazebo.py
+++ b/lbr_bringup/lbr_bringup/gazebo.py
@@ -14,9 +14,9 @@ class GazeboMixin:
             PythonLaunchDescriptionSource(
                 PathJoinSubstitution(
                     [
-                        FindPackageShare("gazebo_ros"),
+                        FindPackageShare("ros_gz_sim"),
                         "launch",
-                        "gazebo.launch.py",
+                        "gz_sim.launch.py",
                     ]
                 )
             ),
@@ -34,13 +34,13 @@ class GazeboMixin:
         label = ["-x", "-y", "-z", "-R", "-P", "-Y"]
         tf = [str(x) for x in tf]
         return Node(
-            package="gazebo_ros",
-            executable="spawn_entity.py",
+            package="ros_gz_sim",
+            executable="create",
             arguments=[
-                "-topic",
-                "robot_description",
-                "-entity",
+                "-name",
                 robot_name,
+                "-topic",
+                "/robot_description",
             ]
             + [item for pair in zip(label, tf) for item in pair],
             output="screen",

--- a/lbr_bringup/package.xml
+++ b/lbr_bringup/package.xml
@@ -18,8 +18,6 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>gazebo_ros</exec_depend>
-  <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>rclpy</exec_depend>
 

--- a/lbr_description/gazebo/lbr_gazebo.xacro
+++ b/lbr_description/gazebo/lbr_gazebo.xacro
@@ -6,7 +6,12 @@
         <gazebo>
             <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
                 <parameters>$(find lbr_ros2_control)/config/lbr_controllers.yaml</parameters>
-                <remapping>~/robot_description:=robot_description</remapping>
+                <robot_param_node>robot_state_publisher</robot_param_node>
+                <robot_param_node>robot_description</robot_param_node>
+                <ros>
+                    <namespace>/${robot_name}</namespace>
+                    <remapping>~/robot_description:=robot_description</remapping>
+                </ros>
             </plugin>
         </gazebo>
 

--- a/lbr_description/gazebo/lbr_gazebo.xacro
+++ b/lbr_description/gazebo/lbr_gazebo.xacro
@@ -4,13 +4,9 @@
 
         <!-- ros_control-plugin -->
         <gazebo>
-            <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
+            <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
                 <parameters>$(find lbr_ros2_control)/config/lbr_controllers.yaml</parameters>
-                <ros>
-                    <namespace>/${robot_name}</namespace>
-                    <!-- remapping for controller manager inside Gazebo plugin -->
-                    <remapping>~/robot_description:=robot_description</remapping>
-                </ros>
+                <remapping>~/robot_description:=robot_description</remapping>
             </plugin>
         </gazebo>
 

--- a/lbr_description/lbr_description.dsv
+++ b/lbr_description/lbr_description.dsv
@@ -1,1 +1,1 @@
-prepend-non-duplicate;GAZEBO_MODEL_PATH;share
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/@PROJECT_NAME@/meshes

--- a/lbr_description/package.xml
+++ b/lbr_description/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_pytest</buildtool_depend>
 
-  <exec_depend>gazebo_ros2_control</exec_depend>
+  <exec_depend>ign_ros2_control</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/lbr_description/urdf/iiwa14/iiwa14_description.xacro
+++ b/lbr_description/urdf/iiwa14/iiwa14_description.xacro
@@ -36,13 +36,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_0.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_0.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_0.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_0.stl" />
                 </geometry>
             </collision>
         </link>
@@ -70,13 +70,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.1475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_1.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_1.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.1475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_1.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_1.stl" />
                 </geometry>
             </collision>
         </link>
@@ -104,13 +104,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.01 -0.36" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_2.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_2.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.01 -0.36" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_2.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_2.stl" />
                 </geometry>
             </collision>
         </link>
@@ -138,13 +138,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.588" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_3.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_3.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.588" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_3.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_3.stl" />
                 </geometry>
             </collision>
         </link>
@@ -172,13 +172,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.78" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_4.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_4.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.78" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_4.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_4.stl" />
                 </geometry>
             </collision>
         </link>
@@ -206,13 +206,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.9875" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_5.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_5.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.9875" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_5.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_5.stl" />
                 </geometry>
             </collision>
         </link>
@@ -240,13 +240,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.18" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_6.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_6.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.18" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_6.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_6.stl" />
                 </geometry>
             </collision>
         </link>
@@ -273,13 +273,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.271" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/visual/link_7.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/visual/link_7.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.271" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa14/collision/link_7.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa14/collision/link_7.stl" />
                 </geometry>
             </collision>
         </link>

--- a/lbr_description/urdf/iiwa7/iiwa7_description.xacro
+++ b/lbr_description/urdf/iiwa7/iiwa7_description.xacro
@@ -36,13 +36,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_0.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_0.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_0.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_0.stl" />
                 </geometry>
             </collision>
         </link>
@@ -70,13 +70,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.1475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_1.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_1.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.1475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_1.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_1.stl" />
                 </geometry>
             </collision>
         </link>
@@ -104,13 +104,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0105 -0.34" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_2.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_2.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0105 -0.34" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_2.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_2.stl" />
                 </geometry>
             </collision>
         </link>
@@ -138,13 +138,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.5475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_3.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_3.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.5475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_3.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_3.stl" />
                 </geometry>
             </collision>
         </link>
@@ -172,13 +172,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.74" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_4.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_4.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.74" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_4.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_4.stl" />
                 </geometry>
             </collision>
         </link>
@@ -206,13 +206,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.9475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_5.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_5.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.9475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_5.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_5.stl" />
                 </geometry>
             </collision>
         </link>
@@ -240,13 +240,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.14" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_6.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_6.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.14" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_6.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_6.stl" />
                 </geometry>
             </collision>
         </link>
@@ -274,13 +274,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.231" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/visual/link_7.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/visual/link_7.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.231" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/iiwa7/collision/link_7.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/iiwa7/collision/link_7.stl" />
                 </geometry>
             </collision>
         </link>

--- a/lbr_description/urdf/med14/med14_description.xacro
+++ b/lbr_description/urdf/med14/med14_description.xacro
@@ -37,13 +37,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_0.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_0.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_0.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_0.stl" />
                 </geometry>
             </collision>
         </link>
@@ -71,13 +71,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.147" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_1.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_1.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.147" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_1.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_1.stl" />
                 </geometry>
             </collision>
         </link>
@@ -105,13 +105,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.01 -0.3595" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_2.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_2.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.01 -0.3595" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_2.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_2.stl" />
                 </geometry>
             </collision>
         </link>
@@ -139,13 +139,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.5875" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_3.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_3.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.5875" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_3.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_3.stl" />
                 </geometry>
             </collision>
         </link>
@@ -173,13 +173,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.7795" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_4.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_4.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.7795" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_4.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_4.stl" />
                 </geometry>
             </collision>
         </link>
@@ -207,13 +207,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.987" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_5.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_5.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.987" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_5.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_5.stl" />
                 </geometry>
             </collision>
         </link>
@@ -241,13 +241,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.1795" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_6.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_6.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.1795" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_6.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_6.stl" />
                 </geometry>
             </collision>
         </link>
@@ -274,13 +274,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.2705" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/visual/link_7.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/visual/link_7.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.2705" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med14/collision/link_7.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med14/collision/link_7.stl" />
                 </geometry>
             </collision>
         </link>

--- a/lbr_description/urdf/med7/med7_description.xacro
+++ b/lbr_description/urdf/med7/med7_description.xacro
@@ -37,13 +37,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_0.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_0.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0 0 0" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_0.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_0.stl" />
                 </geometry>
             </collision>
         </link>
@@ -71,13 +71,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.1475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_1.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_1.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.1475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_1.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_1.stl" />
                 </geometry>
             </collision>
         </link>
@@ -105,13 +105,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0105 -0.34" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_2.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_2.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0105 -0.34" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_2.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_2.stl" />
                 </geometry>
             </collision>
         </link>
@@ -139,13 +139,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.5475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_3.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_3.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.5475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_3.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_3.stl" />
                 </geometry>
             </collision>
         </link>
@@ -173,13 +173,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.74" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_4.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_4.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 -0.0105 -0.74" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_4.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_4.stl" />
                 </geometry>
             </collision>
         </link>
@@ -207,13 +207,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.9475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_5.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_5.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -0.9475" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_5.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_5.stl" />
                 </geometry>
             </collision>
         </link>
@@ -241,13 +241,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.14" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_6.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_6.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0707 -1.14" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_6.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_6.stl" />
                 </geometry>
             </collision>
         </link>
@@ -274,13 +274,13 @@
             <visual>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.231" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/visual/link_7.dae" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/visual/link_7.dae" />
                 </geometry>
             </visual>
             <collision>
                 <origin rpy="0 0 0" xyz="0.0 0.0 -1.231" />
                 <geometry>
-                    <mesh filename="package://lbr_description/meshes/med7/collision/link_7.stl" />
+                    <mesh filename="file://$(find lbr_description)/meshes/med7/collision/link_7.stl" />
                 </geometry>
             </collision>
         </link>

--- a/lbr_ros2_control/config/lbr_system_interface.xacro
+++ b/lbr_ros2_control/config/lbr_system_interface.xacro
@@ -15,7 +15,7 @@
             </xacro:if>
             <xacro:if value="${mode == 'gazebo'}">
                 <hardware>
-                    <plugin>mock_components/GenericSystem</plugin>
+                    <plugin>ign_ros2_control/IgnitionSystem</plugin>
                 </hardware>
             </xacro:if>
             <xacro:if value="${mode == 'hardware'}">

--- a/lbr_ros2_control/config/lbr_system_interface.xacro
+++ b/lbr_ros2_control/config/lbr_system_interface.xacro
@@ -15,7 +15,7 @@
             </xacro:if>
             <xacro:if value="${mode == 'gazebo'}">
                 <hardware>
-                    <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+                    <plugin>mock_components/GenericSystem</plugin>
                 </hardware>
             </xacro:if>
             <xacro:if value="${mode == 'hardware'}">
@@ -98,10 +98,13 @@
                         <param name="min">${min_position}</param>
                         <param name="max">${max_position}</param>
                     </command_interface>
-                    <command_interface name="effort">
-                        <param name="min">-${max_torque}</param>
-                        <param name="max"> ${max_torque}</param>
-                    </command_interface>
+                    <!-- Only Supply one command interface. !TODO! Later make the choice of command interface a cli input argument -->
+                    <xacro:unless value="${mode == 'gazebo'}">                        
+                        <command_interface name="effort">
+                            <param name="min">-${max_torque}</param>
+                            <param name="max"> ${max_torque}</param>
+                        </command_interface>
+                    </xacro:unless>
                     <state_interface name="position" />
                     <state_interface name="velocity" />
                     <state_interface name="effort" />

--- a/lbr_ros2_control/package.xml
+++ b/lbr_ros2_control/package.xml
@@ -16,7 +16,7 @@
   <depend>rclcpp</depend>
   <depend>realtime_tools</depend>
   <depend>ros2_control</depend>
-
+  
   <exec_depend>lbr_description</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
 


### PR DESCRIPTION
### Ignition Gazebo

Ignition Gazebo (Gazebo) will be the predecessor of Gazebo (Gazebo Classic). This PR aims to support Ignition Gazebo for the humble branch.

Currently, most of the functionality in this PR works, except for the interactive marker for MoveIt 2. For early adoption, this repo can be checked out dev-humble-ign. It can be run as usual.

`ros2 launch lbr_bringup gazebo.launch.py`

`ros2 launch lbr_bringup move_group.launch.py mode:=gazebo rviz:=true`


